### PR TITLE
RxJava2 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Local object storage for Java and Android.  Includes...
 
 - Simple & fluent API for key-value storage
 - Convenient timestamp evaluation
-- RxJava Subjects to observe/update
+- RxJava2 Subjects to observe/update
 - Pluggable storage interface (Default is flat file storage. Roll your own - DiskLRUCache, Shared Preferences, SQLite, etc.)
 - Pluggable serialization interface (Default is Gson.  Roll your own - Jackson, Kryo, etc.)
  
@@ -49,7 +49,7 @@ shelf.clear("") //deletes all items
 ```
 
 
-Create RxJava-based CacheSubjects to observe and update shelf items:
+Create RxJava2-based CacheSubjects to observe and update shelf items:
 ```java
 CacheSubject<Pojo> pojoSubject = shelf.item("pojo").subject(Pojo.class);
 pojoSubject.subscribe( /* respond to shelf changes here */ );

--- a/shelf/build.gradle
+++ b/shelf/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testCompile 'com.fasterxml.jackson.core:jackson-databind:2.7.3'
 
     compile 'com.google.code.gson:gson:2.4'
-    compile 'io.reactivex:rxjava:1.1.0'
+    compile 'io.reactivex.rxjava2:rxjava:2.1.2'
 }
 
 targetCompatibility = '1.7'

--- a/shelf/src/main/java/com/toddway/shelf/ShelfItem.java
+++ b/shelf/src/main/java/com/toddway/shelf/ShelfItem.java
@@ -8,8 +8,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import rx.Observable;
-import rx.functions.Action1;
+import io.reactivex.Observable;
+import io.reactivex.ObservableTransformer;
+import io.reactivex.functions.Consumer;
 
 
 public class ShelfItem {
@@ -95,11 +96,11 @@ public class ShelfItem {
         return ShelfSubjectFactory.createForList(this, type);
     }
 
-    public Action1<Object> put() {
-        return new Action1<Object>() {
+    public Consumer<Object> put() {
+        return new Consumer<Object>() {
 
             @Override
-            public void call(Object t) {
+            public void accept(Object t) {
                 put(t);
             }
         };
@@ -113,23 +114,23 @@ public class ShelfItem {
         return new Shelfable<>(null, this, type).observeCache();
     }
 
-    public <T> Observable.Transformer<T, T> cacheThenNew(final Class<T> type) {
+    public <T> ObservableTransformer<T, T> cacheThenNew(final Class<T> type) {
         return Shelfable.cacheThenNew(this, type);
     }
 
-    public <T> Observable.Transformer<T, T> cacheOrNew(final Class<T> type) {
+    public <T> ObservableTransformer<T, T> cacheOrNew(final Class<T> type) {
         return Shelfable.cacheOrNew(this, type);
     }
 
-    public <T> Observable.Transformer<T, T> newOnly(final Class<T> type) {
+    public <T> ObservableTransformer<T, T> newOnly(final Class<T> type) {
         return Shelfable.newOnly(this, type);
     }
 
-    public <T> Observable.Transformer<T, T> pollNew(final Class<T> type, final long value, final TimeUnit unit) {
+    public <T> ObservableTransformer<T, T> pollNew(final Class<T> type, final long value, final TimeUnit unit) {
         return Shelfable.pollNew(this, type, value, unit);
     }
 
-    public <T> Observable.Transformer<T, T> cacheThenPollNew(final Class<T> type, final long value, final TimeUnit unit) {
+    public <T> ObservableTransformer<T, T> cacheThenPollNew(final Class<T> type, final long value, final TimeUnit unit) {
         return Shelfable.cacheThenPollNew(this, type, value, unit);
     }
 }

--- a/shelf/src/main/java/com/toddway/shelf/ShelfUtils.java
+++ b/shelf/src/main/java/com/toddway/shelf/ShelfUtils.java
@@ -13,7 +13,7 @@ public class ShelfUtils {
 
     public static boolean hasRxOnClasspath() {
         try {
-            Class.forName("rx.Observable");
+            Class.forName("io.reactivex.Observable");
             return true;
         } catch (ClassNotFoundException e) {
             e.printStackTrace();
@@ -27,7 +27,7 @@ public class ShelfUtils {
 
     public static void checkRx() {
         if (!hasRxOnClasspath()) {
-            throw new NoClassDefFoundError("RxJava is not on classpath, add it to your dependencies");
+            throw new NoClassDefFoundError("RxJava2 is not on classpath, add it to your dependencies");
         }
     }
 

--- a/shelf/src/main/java/com/toddway/shelf/Shelfable.java
+++ b/shelf/src/main/java/com/toddway/shelf/Shelfable.java
@@ -4,7 +4,8 @@ import com.toddway.shelf.rx.RxCacheable;
 
 import java.util.concurrent.TimeUnit;
 
-import rx.Observable;
+import io.reactivex.Observable;
+import io.reactivex.ObservableTransformer;
 
 /**
  * Created by tway on 4/24/16.
@@ -38,46 +39,46 @@ public class Shelfable<T> extends RxCacheable<T> {
         item.put(t);
     }
 
-    public static <T> Observable.Transformer<T, T> cacheThenNew(final ShelfItem item, final Class<T> type) {
-        return new Observable.Transformer<T, T>() {
+    public static <T> ObservableTransformer<T, T> cacheThenNew(final ShelfItem item, final Class<T> type) {
+        return new ObservableTransformer<T, T>() {
             @Override
-            public Observable<T> call(Observable<T> observable) {
+            public Observable<T> apply(Observable<T> observable) {
                 return new Shelfable<>(observable, item, type).observeCacheThenNew();
             }
         };
     }
 
-    public static <T> Observable.Transformer<T, T> cacheOrNew(final ShelfItem item, final Class<T> type) {
-        return new Observable.Transformer<T, T>() {
+    public static <T> ObservableTransformer<T, T> cacheOrNew(final ShelfItem item, final Class<T> type) {
+        return new ObservableTransformer<T, T>() {
             @Override
-            public Observable<T> call(Observable<T> observable) {
-                return new Shelfable<>(observable, item, type).observeCacheOrNew();
+            public Observable<T> apply(Observable<T> observable) {
+                return (new Shelfable<>(observable, item, type).observeCacheOrNew()).toObservable();
             }
         };
     }
 
-    public static <T> Observable.Transformer<T, T> newOnly(final ShelfItem item, final Class<T> type) {
-        return new Observable.Transformer<T, T>() {
+    public static <T> ObservableTransformer<T, T> newOnly(final ShelfItem item, final Class<T> type) {
+        return new ObservableTransformer<T, T>() {
             @Override
-            public Observable<T> call(Observable<T> observable) {
+            public Observable<T> apply(Observable<T> observable) {
                 return new Shelfable<>(observable, item, type).observeNewOnly();
             }
         };
     }
 
-    public static <T> Observable.Transformer<T, T> pollNew(final ShelfItem item, final Class<T> type, final long value, final TimeUnit unit) {
-        return new Observable.Transformer<T, T>() {
+    public static <T> ObservableTransformer<T, T> pollNew(final ShelfItem item, final Class<T> type, final long value, final TimeUnit unit) {
+        return new ObservableTransformer<T, T>() {
             @Override
-            public Observable<T> call(Observable<T> observable) {
+            public Observable<T> apply(Observable<T> observable) {
                 return new Shelfable<>(observable, item, type).pollNew(value, unit);
             }
         };
     }
 
-    public static <T> Observable.Transformer<T, T> cacheThenPollNew(final ShelfItem item, final Class<T> type, final long value, final TimeUnit unit) {
-        return new Observable.Transformer<T, T>() {
+    public static <T> ObservableTransformer<T, T> cacheThenPollNew(final ShelfItem item, final Class<T> type, final long value, final TimeUnit unit) {
+        return new ObservableTransformer<T, T>() {
             @Override
-            public Observable<T> call(Observable<T> observable) {
+            public Observable<T> apply(Observable<T> observable) {
                 return new Shelfable<>(observable, item, type).observeCacheThenPollNew(value, unit);
             }
         };

--- a/shelf/src/main/java/com/toddway/shelf/rx/ShelfSubjectFactory.java
+++ b/shelf/src/main/java/com/toddway/shelf/rx/ShelfSubjectFactory.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 public class ShelfSubjectFactory {
 

--- a/shelf/src/test/java/com/toddway/shelf/BaseTest.java
+++ b/shelf/src/test/java/com/toddway/shelf/BaseTest.java
@@ -5,7 +5,8 @@ import org.junit.Before;
 import java.io.File;
 import java.util.List;
 
-import rx.observers.TestSubscriber;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.subscribers.TestSubscriber;
 
 /**
  * Created by tway on 1/11/17.
@@ -14,7 +15,7 @@ import rx.observers.TestSubscriber;
 public class BaseTest {
 
     ShelfItem item;
-    TestSubscriber<String> subscriber;
+    TestObserver<String> subscriber;
     Shelf shelf;
     String newValue;
     String cacheValue;
@@ -23,7 +24,7 @@ public class BaseTest {
     public void beforeEach() {
         shelf = new Shelf(new File("/tmp"));
         item = shelf.item("string");
-        subscriber = new TestSubscriber<>();
+        subscriber = new TestObserver<>();
         newValue = "new value";
         cacheValue = "cache value";
     }

--- a/shelf/src/test/java/com/toddway/shelf/CacheOrNewTests.java
+++ b/shelf/src/test/java/com/toddway/shelf/CacheOrNewTests.java
@@ -6,8 +6,8 @@ import org.junit.Test;
 import java.io.File;
 import java.util.List;
 
-import rx.Observable;
-import rx.observers.TestSubscriber;
+import io.reactivex.Observable;
+import io.reactivex.observers.TestObserver;
 
 import static org.junit.Assert.assertEquals;
 
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertEquals;
 public class CacheOrNewTests {
 
     ShelfItem item;
-    TestSubscriber<String> subscriber;
+    TestObserver<String> subscriber;
     Shelf shelf;
     String newValue;
     String cacheValue;
@@ -26,7 +26,7 @@ public class CacheOrNewTests {
     public void beforeEach() {
         shelf = new Shelf(new File("/tmp"));
         item = shelf.item("string");
-        subscriber = new TestSubscriber<>();
+        subscriber = new TestObserver<>();
         newValue = "new value";
         cacheValue = "cache value";
     }
@@ -64,7 +64,7 @@ public class CacheOrNewTests {
 
         subscriber.assertValues(newValue);
         assertEquals(item.get(String.class), newValue);
-        printValues(subscriber.getOnNextEvents());
+        //printValues(subscriber.getOnNextEvents());
     }
 
 
@@ -76,7 +76,7 @@ public class CacheOrNewTests {
         subscriber.assertValues(cacheValue);
         subscriber.assertNoErrors();
         assertEquals(item.get(String.class), cacheValue);
-        printValues(subscriber.getOnNextEvents());
+        //printValues(subscriber.getOnNextEvents());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class CacheOrNewTests {
 
         subscriber.assertValues(newValue);
         assertEquals(item.get(String.class), newValue);
-        printValues(subscriber.getOnNextEvents());
+        //printValues(subscriber.getOnNextEvents());
     }
 
     @Test public void testNoCacheAndNoNew() {
@@ -96,7 +96,7 @@ public class CacheOrNewTests {
 
         subscriber.assertNoValues();
         assertEquals(item.get(String.class), null);
-        printValues(subscriber.getOnNextEvents());
+        //printValues(subscriber.getOnNextEvents());
     }
 
     @Test public void  testNoNewAndInvalidCache() {
@@ -106,6 +106,6 @@ public class CacheOrNewTests {
 
         subscriber.assertNoValues();
         assertEquals(item.get(String.class), cacheValue);
-        printValues(subscriber.getOnNextEvents());
+        //printValues(subscriber.getOnNextEvents());
     }
 }

--- a/shelf/src/test/java/com/toddway/shelf/CacheThenNewTests.java
+++ b/shelf/src/test/java/com/toddway/shelf/CacheThenNewTests.java
@@ -7,8 +7,8 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import rx.Observable;
-import rx.observers.TestSubscriber;
+import io.reactivex.Observable;
+import io.reactivex.observers.TestObserver;
 
 import static org.junit.Assert.assertEquals;
 
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertEquals;
 public class CacheThenNewTests {
 
     ShelfItem item;
-    TestSubscriber<String> subscriber;
+    TestObserver<String> subscriber;
     Shelf shelf;
     String newValue;
     String cacheValue;
@@ -28,7 +28,7 @@ public class CacheThenNewTests {
     public void beforeEach() {
         shelf = new Shelf(new File("/tmp"));
         item = shelf.item("string");
-        subscriber = new TestSubscriber<>();
+        subscriber = new TestObserver<>();
         newValue = "new value";
         cacheValue = "cache value";
     }
@@ -67,7 +67,10 @@ public class CacheThenNewTests {
         subscriber.assertValues(null, newValue);
         assertEquals(item.get(String.class), newValue);
 
-        printValues(subscriber.getOnNextEvents());
+        // TODO New TestObserver does not contain the getOnNextEvents method, nor a clear similar
+        // method.  Call has been commented out to allow compiling, until such time as a replacement
+        // is built into RxJava2.
+        // printValues(subscriber.getOnNextEvents());
     }
 
     @Test
@@ -77,7 +80,10 @@ public class CacheThenNewTests {
 
         subscriber.assertValues(cacheValue);
         assertEquals(item.get(String.class), cacheValue);
-        printValues(subscriber.getOnNextEvents());
+        // TODO New TestObserver does not contain the getOnNextEvents method, nor a clear similar
+        // method.  Call has been commented out to allow compiling, until such time as a replacement
+        // is built into RxJava2.
+        // printValues(subscriber.getOnNextEvents());
     }
 
     @Test
@@ -87,7 +93,10 @@ public class CacheThenNewTests {
 
         subscriber.assertValues(cacheValue, newValue);
         assertEquals(item.get(String.class), newValue);
-        printValues(subscriber.getOnNextEvents());
+        // TODO New TestObserver does not contain the getOnNextEvents method, nor a clear similar
+        // method.  Call has been commented out to allow compiling, until such time as a replacement
+        // is built into RxJava2.
+        // printValues(subscriber.getOnNextEvents());
     }
 
     @Test public void testNoCacheAndNoNew() {
@@ -95,9 +104,12 @@ public class CacheThenNewTests {
         givenNoNew();
         whenCacheThenNewSubscription();
 
-        subscriber.assertValue(null);
+        subscriber.assertValue((String)null);
         assertEquals(item.get(String.class), null);
-        printValues(subscriber.getOnNextEvents());
+        // TODO New TestObserver does not contain the getOnNextEvents method, nor a clear similar
+        // method.  Call has been commented out to allow compiling, until such time as a replacement
+        // is built into RxJava2.
+        // printValues(subscriber.getOnNextEvents());
     }
 
     @Test public void  testNoNewAndInvalidCache() {
@@ -107,6 +119,9 @@ public class CacheThenNewTests {
 
         subscriber.assertValues(cacheValue);
         assertEquals(item.get(String.class), cacheValue);
-        printValues(subscriber.getOnNextEvents());
+        // TODO New TestObserver does not contain the getOnNextEvents method, nor a clear similar
+        // method.  Call has been commented out to allow compiling, until such time as a replacement
+        // is built into RxJava2.
+        // printValues(subscriber.getOnNextEvents());
     }
 }

--- a/shelf/src/test/java/com/toddway/shelf/CachedSubjectTests.java
+++ b/shelf/src/test/java/com/toddway/shelf/CachedSubjectTests.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-import rx.observers.TestSubscriber;
+import io.reactivex.observers.TestObserver;
 
 /**
  * Created by tway on 1/11/17.
@@ -16,7 +16,7 @@ public class CachedSubjectTests extends BaseTest {
 
     CacheSubject<String> itemCache;
     CacheSubject<String[]> listCache;
-    TestSubscriber<String[]> listSubscriber;
+    TestObserver<String[]> listSubscriber;
     ShelfItem listItem;
 
     @Override
@@ -25,15 +25,14 @@ public class CachedSubjectTests extends BaseTest {
         listItem = shelf.item("list");
         itemCache = item.subject(String.class);
         listCache = listItem.subject(String[].class);
-        listSubscriber = new TestSubscriber<>();
+        listSubscriber = new TestObserver<>();
     }
-
 
     @Test public void testNoCache() {
         givenNoCache();
         itemCache.subscribe(subscriber);
 
-        subscriber.assertValue(null);
+        subscriber.assertValue((String)null);
 
         itemCache.onNext(newValue);
 
@@ -43,9 +42,11 @@ public class CachedSubjectTests extends BaseTest {
 
         subscriber.assertValues(null, newValue, newValue);
 
-        //printValues(subscriber.getOnNextEvents());
+        // TODO New TestObserver does not contain the getOnNextEvents method, nor a clear similar
+        // method.  Call has been commented out to allow compiling, until such time as a replacement
+        // is built into RxJava2.
+        // printValues(subscriber.getOnNextEvents());
     }
-
 
     @Test public void testWithCache() {
         givenInvalidCache();
@@ -61,7 +62,10 @@ public class CachedSubjectTests extends BaseTest {
 
         subscriber.assertValues(cacheValue, newValue, newValue);
 
-        //printValues(subscriber.getOnNextEvents());
+        // TODO New TestObserver does not contain the getOnNextEvents method, nor a clear similar
+        // method.  Call has been commented out to allow compiling, until such time as a replacement
+        // is built into RxJava2.
+        // printValues(subscriber.getOnNextEvents());
     }
 
     @Test public void testList() {
@@ -69,7 +73,7 @@ public class CachedSubjectTests extends BaseTest {
         listSubscriber.assertNoValues();
 
         listCache.subscribe(listSubscriber);
-        listSubscriber.assertValue(null);
+        listSubscriber.assertValue((String[])null);
 
         //itemCache.onError(new RuntimeException("test"));
 
@@ -83,11 +87,12 @@ public class CachedSubjectTests extends BaseTest {
         listSubscriber.assertValueCount(1);
 
         System.out.println("\nlist values...");
-        for (String[] a : listSubscriber.getOnNextEvents()) {
-            if (a == null)System.out.println("null");
-            else printValues(Arrays.asList(a));
-        }
-
-
+        // TODO New TestObserver does not contain the getOnNextEvents method, nor a clear similar
+        // method.  Call has been commented out to allow compiling, until such time as a replacement
+        // is built into RxJava2.
+        // for (String[] a : listSubscriber.getOnNextEvents()) {
+        //    if (a == null)System.out.println("null");
+        //    else printValues(Arrays.asList(a));
+        //}
     }
 }

--- a/shelf/src/test/java/com/toddway/shelf/SyncSource.java
+++ b/shelf/src/test/java/com/toddway/shelf/SyncSource.java
@@ -1,6 +1,6 @@
 package com.toddway.shelf;
 
-import rx.Observable;
+import io.reactivex.Observable;
 
 /**
  * Created by tway on 1/11/17.
@@ -32,7 +32,7 @@ public class SyncSource<T>  {
 //                        return update(t);
 //                    }
 //                })
-////                .doOnNext(new Action1<T>() {
+////                .doOnNext(new Consumer<T>() {
 ////                    @Override
 ////                    public void call(T t) {
 ////                        timestamp = System.currentTimeMillis();


### PR DESCRIPTION
Attempting to update project from RxJava1 to RxJava2, relying upon Shelf for a portion of the project, and needing updated to RxJava2.  Since it was re-written, rather than simply updated, there are not always clear 1-to-1 references between what things were and what they should be. 

Updated class name referrences, object creations, method names, and other associated references between RxJava1 and RxJava2.

Testing was not refactored, new TextObserver did not contain the same method call getOnNextEvents, and there was no clear reference to a new replacement method.